### PR TITLE
Add a preprocessor to automatically add file names in the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ npm install karma-junit7-sonarqube-reporter --save-dev
 // karma.conf.js
 module.exports = function(config) {
   config.set({
+    preprocessors: {
+      'test/**/*.spec.js': ['junit']
+    },
+
     reporters: ['progress', 'junit'],
 
     // the default configuration

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,0 +1,16 @@
+(function(window) {
+
+  var currentFile;
+  var originalResult = window.__karma__.result;
+
+  window.__karma__.result = function(result) {
+    if (currentFile) {
+      result.filename = currentFile;
+    }
+    originalResult.call(window.__karma__, result);
+  };
+
+  window.__setCurrentFile = function(f) {
+    currentFile = f;
+  };
+})(window);


### PR DESCRIPTION
Hi,

Since it's a bit inconvenient to write suite names that match their file paths, I wrote this PR to get the filename automatically. It uses a new preprocessor that calls a global function to store the path of the current test file.

As I explained in the README, it's necessary to add 'junit' in the preprocessors conf to enable this feature.
